### PR TITLE
Set locale for DateFormatter

### DIFF
--- a/S3Middleware/S3Middleware.swift
+++ b/S3Middleware/S3Middleware.swift
@@ -57,6 +57,7 @@ class S3RequestHeadersBuilder {
         let now = Date()
         let dateFormatter = DateFormatter()
         dateFormatter.timeZone = TimeZone(secondsFromGMT: 0)
+        dateFormatter.locale = Locale(identifier: "en_US_POSIX")
         dateFormatter.dateFormat = "yyyMMdd'T'HHmmss'Z'"
         amzDate = dateFormatter.string(from: now)
         dateFormatter.dateFormat = "yyyMMdd"


### PR DESCRIPTION
Not setting the locale for the DateFormatter can generate different date formats depending on the user's own region settings.

I personally noticed this during my own testing in the UK where the formatter would generate a 12-hour string with am/pm e.g. `20251014T120402 AMZ`.

As per [this Apple documentation](https://developer.apple.com/library/archive/qa/qa1480/_index.html), it is recommended to set the locale to `en_US_POSIX` which should generate predictable results every time.